### PR TITLE
Add builder for wheels in Windows, Mac and Linux [python.311]

### DIFF
--- a/.github/workflows/python-builder.yml
+++ b/.github/workflows/python-builder.yml
@@ -22,12 +22,22 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
-      - uses: microsoft/setup-msbuild@v1.1
+        with:
+          python-version: '3.11'
+      # install Visual Studio 2022 Community
+      - name: Install Visual Studio 2022 Community
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: x64
+          vs_version: 17.0
+          use: host
+
+
       - name: Build Loris
       #  Import-Module Microsoft.VisualStudio.DevShell.dll
       # then go to the git repo and run the python script
         run: |
-          cd "C:\Program Files\Microsoft Visual Studio\2019\Community"
+          cd "C:\Program Files\Microsoft Visual Studio\2022\Community"
           powershell  -NoExit -Command "Import-Module ./Common7/Tools/Microsoft.VisualStudio.DevShell.dll; Enter-VsDevShell d718e166 -SkipAutomaticLocation"
           cd {github.workspace}      
           python scripts/prepare_windows_build.py

--- a/.github/workflows/python-builder.yml
+++ b/.github/workflows/python-builder.yml
@@ -16,17 +16,20 @@ jobs:
       matrix:
         os: [windows-latest]
     
+    # python scripts/prepare_windows_build.py
+
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
-        with:
-          python-version: '3.11'
-      - uses: ilammy/msvc-dev-cmd@v1
-        with:
-          arch: ${{ matrix.arch }}
-      - name: Build something requiring CL.EXE
+      - uses: microsoft/setup-msbuild@v1.1
+      - name: Build Loris
         run: |
           python scripts/prepare_windows_build.py
+
+
+
+
+
 
 
 

--- a/.github/workflows/python-builder.yml
+++ b/.github/workflows/python-builder.yml
@@ -24,17 +24,17 @@ jobs:
         with:
           python-version: 3.11
 
-      - name: Install Visual Studio Build Tools
-        run: |
-            choco install visualstudio2019buildtools --package-parameters "--includeRecommended --includeOptional --passive --add Microsoft.VisualStudio.Workload.MSBuildTools --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64"
-
       - name: Setup Developer PowerShell
         run: |
           "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\Common7\Tools\VsDevCmd.bat"
 
       - name: Run in Developer Powershell
+        shell: pwsh
         run: |
           python scripts/prepare_windows_build.py
+
+        
+        # python scripts/prepare_windows_build.py
           
       
 

--- a/.github/workflows/python-builder.yml
+++ b/.github/workflows/python-builder.yml
@@ -24,22 +24,13 @@ jobs:
         with:
           python-version: 3.11
 
-      - name: Install dependencies Windows
-        if: runner.os == 'windows'
+      - name: Install Visual Studio Build Tools
+        uses: ilammy/msvc-dev-cmd@v1
         # Go to a Developer Command Prompt
         run: |
             python scripts/prepare_windows_build.py
             dir
 
-      - name: Prepare Build for Windows
-        run : |
-            powershell.exe -NoExit -Command "&{Import-Module """C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\Tools\Microsoft.VisualStudio.DevShell.dll"""; Enter-VsDevShell d718e166 -SkipAutomaticLocation -DevCmdArguments """-arch=x64 -host_arch=x64"""}" && python scripts/prepare_windows_build.py
 
-
-      - name: Build using wheel
-        run: |
-            python -m pip install wheel
-            python setup.py bdist_wheel
-            dir
 
 

--- a/.github/workflows/python-builder.yml
+++ b/.github/workflows/python-builder.yml
@@ -28,7 +28,6 @@ jobs:
         if: runner.os == 'windows'
         # Go to a Developer Command Prompt
         run: |
-            choco install libsndfile
             python scripts/prepare_windows_build.py
             dir
 

--- a/.github/workflows/python-builder.yml
+++ b/.github/workflows/python-builder.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           python-version: '3.11'
       # install Visual Studio 2022 Community
-      - name: Install Visual Studio 2022 Community
+      - name: Install Visual Studio 2022 
         uses: ilammy/msvc-dev-cmd@v1
         with:
           arch: x64
@@ -35,11 +35,11 @@ jobs:
 
       - name: Build Loris
       #  Import-Module Microsoft.VisualStudio.DevShell.dll
-      # then go to the git repo and run the python script
+      # then go to the git repo 
         run: |
           cd "C:\Program Files\Microsoft Visual Studio\2022\Enterprise"
           powershell  -NoExit -Command "Import-Module ./Common7/Tools/Microsoft.VisualStudio.DevShell.dll; Enter-VsDevShell d718e166 -SkipAutomaticLocation"
-          cd {github.workspace}      
+          cd "C:\Users\runneradmin\loristrck"   
           python scripts/prepare_windows_build.py
 
 

--- a/.github/workflows/python-builder.yml
+++ b/.github/workflows/python-builder.yml
@@ -62,7 +62,7 @@ jobs:
           
             # if linux, install fftw  
       - name: Install fftw for Linux
-        if: matrix.os == 'ubuntu-20.04'
+        if: matrix.os == 'ubuntu-latest'
         run: sudo apt-get install libfftw3-dev
       
       # if macos, install fftw

--- a/.github/workflows/python-builder.yml
+++ b/.github/workflows/python-builder.yml
@@ -18,6 +18,7 @@ jobs:
     
     # python scripts/prepare_windows_build.py
 
+
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
@@ -26,7 +27,7 @@ jobs:
       #  Import-Module Microsoft.VisualStudio.DevShell.dll
       # then go to the git repo and run the python script
         run: |
-          cd "C:\Program Files\Microsoft Visual Studio\2022\Community"
+          cd "C:\Program Files\Microsoft Visual Studio\2019\Community"
           powershell  -NoExit -Command "Import-Module ./Common7/Tools/Microsoft.VisualStudio.DevShell.dll; Enter-VsDevShell d718e166 -SkipAutomaticLocation"
           cd {github.workspace}      
           python scripts/prepare_windows_build.py

--- a/.github/workflows/python-builder.yml
+++ b/.github/workflows/python-builder.yml
@@ -60,6 +60,16 @@ jobs:
         with:
           python-version: '3.11'
           
+            # if linux, install fftw  
+      - name: Install fftw for Linux
+        if: matrix.os == 'ubuntu-20.04'
+        run: sudo apt-get install libfftw3-dev
+      
+      # if macos, install fftw
+      - name: Install fftw for MacOS
+        if: matrix.os == 'macOS-11'
+        run: brew install fftw
+
       - name: Build wheels
         run: |
           python -m pip install wheel

--- a/.github/workflows/python-builder.yml
+++ b/.github/workflows/python-builder.yml
@@ -41,7 +41,7 @@ jobs:
           Write-Output "Current Location is $($PWD.Path)"
           cd "C:\Program Files\Microsoft Visual Studio\2022\Enterprise"
           powershell  -NoExit -Command "Import-Module ./Common7/Tools/Microsoft.VisualStudio.DevShell.dll; Enter-VsDevShell d718e166 -SkipAutomaticLocation"
-          cd "D:\a\loristrck\loristrck"
+          cd ${{github.workspace}}
           python scripts/prepare_windows_build.py
 
 

--- a/.github/workflows/python-builder.yml
+++ b/.github/workflows/python-builder.yml
@@ -41,7 +41,7 @@ jobs:
           Write-Output "Current Location is $($PWD.Path)"
           cd "C:\Program Files\Microsoft Visual Studio\2022\Enterprise"
           powershell  -NoExit -Command "Import-Module ./Common7/Tools/Microsoft.VisualStudio.DevShell.dll; Enter-VsDevShell d718e166 -SkipAutomaticLocation"
-          cd "C:\Users\runneradmin\work\loristrck\loristrck"
+          cd "D:\a\loristrck\loristrck"
           python scripts/prepare_windows_build.py
 
 

--- a/.github/workflows/python-builder.yml
+++ b/.github/workflows/python-builder.yml
@@ -29,14 +29,9 @@ jobs:
         uses: ilammy/msvc-dev-cmd@v1
         with:
           arch: x64
-          vs_version: 17.0
-          use: host
 
 
       - name: Build Loris
-      # fir print where I am
-      #  Import-Module Microsoft.VisualStudio.DevShell.dll
-      # then go to the git repo 
         run: |
           Write-Output "Current Location is $($PWD.Path)"
           cd "C:\Program Files\Microsoft Visual Studio\2022\Enterprise"
@@ -44,7 +39,10 @@ jobs:
           cd ${{github.workspace}}
           python scripts/prepare_windows_build.py
 
-
+    - name: Build wheels
+      run: |
+        python -m pip install wheel
+        python setup.py bdist_wheel
 
 
 

--- a/.github/workflows/python-builder.yml
+++ b/.github/workflows/python-builder.yml
@@ -15,22 +15,18 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest]
+    
     steps:
       - uses: actions/checkout@v2
-
-      # Use python3.11
-      - name: Setup python
-        uses: actions/setup-python@v2
+      - uses: actions/setup-python@v2
         with:
-          python-version: 3.11
-
-      steps: 
-        # run in Developer Powershell"C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\Common7\Tools\VsDevCmd.bat"
-        - uses: ilammy/msvc-dev-cmd@v1
-        - name: Build Loris
-          run: |
-            python scripts/prepare_windows_build.py
-
+          python-version: '3.11'
+      - uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: ${{ matrix.arch }}
+      - name: Build something requiring CL.EXE
+        run: |
+          python scripts/prepare_windows_build.py
 
 
 

--- a/.github/workflows/python-builder.yml
+++ b/.github/workflows/python-builder.yml
@@ -7,6 +7,35 @@ on:
     branches: [ "master" ]
 
 jobs:
-  build:
+  
+# Make Windows build
+  Windows_build_wheels:
+    name: Build python wheels on ${{ matrix.os }} 
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [windows-latest]
+    steps:
+      - uses: actions/checkout@v2
+
+      # Use python3.11
+      - name: Setup python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.11
+
+      - name: Install dependencies Windows
+        if: runner.os == 'windows'
+        # Go to a Developer Command Prompt
+        run: |
+            choco install libsndfile fftw
+            python scripts/prepare_windows_build.py
+            dir
+
+      - name: Build using wheel
+        run: |
+            python -m pip install wheel
+            python setup.py bdist_wheel
+            dir
 
 

--- a/.github/workflows/python-builder.yml
+++ b/.github/workflows/python-builder.yml
@@ -11,14 +11,11 @@ jobs:
 # Make Windows build
   Windows_build_wheels:
     name: Build python wheels on ${{ matrix.os }} 
-    runs-on: ${{ matrix.os }}
+    runs-on: Windows-latest
     strategy:
       matrix:
         os: [windows-latest]
     
-    # python scripts/prepare_windows_build.py
-
-
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
@@ -29,7 +26,6 @@ jobs:
         uses: ilammy/msvc-dev-cmd@v1
         with:
           arch: x64
-
 
       - name: Build Loris
         run: |
@@ -51,6 +47,29 @@ jobs:
           path: dist/*.whl
 
 # Make Linux build
+  Linux_build_wheels:
+    name: Build python wheels on ${{ matrix.os }} 
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.11'
+          
+      - name: Build wheels
+        run: |
+          python -m pip install wheel
+          python setup.py bdist_wheel
+
+      - name: Upload wheels
+        uses: actions/upload-artifact@v3
+        with:
+          name: wheels
+          path: dist/*.whl
 
 
 

--- a/.github/workflows/python-builder.yml
+++ b/.github/workflows/python-builder.yml
@@ -34,12 +34,14 @@ jobs:
 
 
       - name: Build Loris
+      # fir print where I am
       #  Import-Module Microsoft.VisualStudio.DevShell.dll
       # then go to the git repo 
         run: |
+          Write-Output "Current Location is $($PWD.Path)"
           cd "C:\Program Files\Microsoft Visual Studio\2022\Enterprise"
           powershell  -NoExit -Command "Import-Module ./Common7/Tools/Microsoft.VisualStudio.DevShell.dll; Enter-VsDevShell d718e166 -SkipAutomaticLocation"
-          cd "C:\Users\runneradmin\loristrck"   
+          cd "C:\Users\runneradmin\work\loristrck\loristrck"
           python scripts/prepare_windows_build.py
 
 

--- a/.github/workflows/python-builder.yml
+++ b/.github/workflows/python-builder.yml
@@ -23,7 +23,12 @@ jobs:
       - uses: actions/setup-python@v2
       - uses: microsoft/setup-msbuild@v1.1
       - name: Build Loris
+      #  Import-Module Microsoft.VisualStudio.DevShell.dll
+      # then go to the git repo and run the python script
         run: |
+          cd "C:\Program Files\Microsoft Visual Studio\2022\Community"
+          powershell  -NoExit -Command "Import-Module ./Common7/Tools/Microsoft.VisualStudio.DevShell.dll; Enter-VsDevShell d718e166 -SkipAutomaticLocation"
+          cd {github.workspace}      
           python scripts/prepare_windows_build.py
 
 

--- a/.github/workflows/python-builder.yml
+++ b/.github/workflows/python-builder.yml
@@ -67,7 +67,7 @@ jobs:
       
       # if macos, install fftw
       - name: Install fftw for MacOS
-        if: matrix.os == 'macOS-11'
+        if: matrix.os == 'macos-latest'
         run: brew install fftw
 
       - name: Build wheels

--- a/.github/workflows/python-builder.yml
+++ b/.github/workflows/python-builder.yml
@@ -29,14 +29,10 @@ jobs:
           "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\Common7\Tools\VsDevCmd.bat"
 
       - name: Run in Developer Powershell
-        shell: pwsh
+        # run in Developer Powershell"C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\Common7\Tools\VsDevCmd.bat"
         run: |
-          python scripts/prepare_windows_build.py
+          "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\Common7\Tools\VsDevCmd.bat" && python scripts/prepare_windows_build.py
 
-        
-        # python scripts/prepare_windows_build.py
-          
-      
 
 
 

--- a/.github/workflows/python-builder.yml
+++ b/.github/workflows/python-builder.yml
@@ -25,11 +25,20 @@ jobs:
           python-version: 3.11
 
       - name: Install Visual Studio Build Tools
-        uses: ilammy/msvc-dev-cmd@v1
-        # Go to a Developer Command Prompt
         run: |
-            python scripts/prepare_windows_build.py
-            dir
+            choco install visualstudio2019buildtools --package-parameters "--includeRecommended --includeOptional --passive --add Microsoft.VisualStudio.Workload.MSBuildTools --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64"
+
+      - name: Setup Developer PowerShell
+        run: |
+          "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\Common7\Tools\VsDevCmd.bat"
+
+      - name: Run in Developer Powershell
+        run: |
+          python scripts/prepare_windows_build.py
+          
+      
+
+
 
 
 

--- a/.github/workflows/python-builder.yml
+++ b/.github/workflows/python-builder.yml
@@ -44,6 +44,14 @@ jobs:
           python -m pip install wheel
           python setup.py bdist_wheel
 
+      - name: Upload wheels
+        uses: actions/upload-artifact@v3
+        with:
+          name: wheels
+          path: dist/*.whl
+
+# Make Linux build
+
 
 
 

--- a/.github/workflows/python-builder.yml
+++ b/.github/workflows/python-builder.yml
@@ -1,0 +1,12 @@
+name: C/C++ CI
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+
+

--- a/.github/workflows/python-builder.yml
+++ b/.github/workflows/python-builder.yml
@@ -28,9 +28,14 @@ jobs:
         if: runner.os == 'windows'
         # Go to a Developer Command Prompt
         run: |
-            choco install libsndfile fftw
+            choco install libsndfile
             python scripts/prepare_windows_build.py
             dir
+
+      - name: Prepare Build for Windows
+        run : |
+            powershell.exe -NoExit -Command "&{Import-Module """C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\Tools\Microsoft.VisualStudio.DevShell.dll"""; Enter-VsDevShell d718e166 -SkipAutomaticLocation -DevCmdArguments """-arch=x64 -host_arch=x64"""}" && python scripts/prepare_windows_build.py
+
 
       - name: Build using wheel
         run: |

--- a/.github/workflows/python-builder.yml
+++ b/.github/workflows/python-builder.yml
@@ -24,16 +24,12 @@ jobs:
         with:
           python-version: 3.11
 
-      - name: Setup Developer PowerShell
-        run: |
-          "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\Common7\Tools\VsDevCmd.bat"
-
       - name: Run in Developer Powershell
         # run in Developer Powershell"C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\Common7\Tools\VsDevCmd.bat"
-        run: |
-          "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\Common7\Tools\VsDevCmd.bat" && python scripts/prepare_windows_build.py
-
-
+        - uses: ilammy/msvc-dev-cmd@v1
+        - name: Build Loris
+          run: |
+            python scripts/prepare_windows_build.py
 
 
 

--- a/.github/workflows/python-builder.yml
+++ b/.github/workflows/python-builder.yml
@@ -37,7 +37,7 @@ jobs:
       #  Import-Module Microsoft.VisualStudio.DevShell.dll
       # then go to the git repo and run the python script
         run: |
-          cd "C:\Program Files\Microsoft Visual Studio\2022\Community"
+          cd "C:\Program Files\Microsoft Visual Studio\2022\Enterprise"
           powershell  -NoExit -Command "Import-Module ./Common7/Tools/Microsoft.VisualStudio.DevShell.dll; Enter-VsDevShell d718e166 -SkipAutomaticLocation"
           cd {github.workspace}      
           python scripts/prepare_windows_build.py

--- a/.github/workflows/python-builder.yml
+++ b/.github/workflows/python-builder.yml
@@ -39,10 +39,10 @@ jobs:
           cd ${{github.workspace}}
           python scripts/prepare_windows_build.py
 
-    - name: Build wheels
-      run: |
-        python -m pip install wheel
-        python setup.py bdist_wheel
+      - name: Build wheels
+        run: |
+          python -m pip install wheel
+          python setup.py bdist_wheel
 
 
 

--- a/.github/workflows/python-builder.yml
+++ b/.github/workflows/python-builder.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           python-version: 3.11
 
-      - name: Run in Developer Powershell
+      steps: 
         # run in Developer Powershell"C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\Common7\Tools\VsDevCmd.bat"
         - uses: ilammy/msvc-dev-cmd@v1
         - name: Build Loris

--- a/setup.py
+++ b/setup.py
@@ -68,16 +68,15 @@ elif sys.platform == 'linux':
 ######################################
 elif sys.platform == 'win32':
     if not os.path.exists('src/loriswin'):
-        
-        
-    assert os.path.exists('src/loriswin'), (
-        "Source files for windows not found. From a 'Developer Command Prompt' "
-        "run scripts/prepare_windows_build.py first")
+                
+        assert os.path.exists('src/loriswin'), (
+            "Source files for windows not found. From a 'Developer Command Prompt' "
+            "run scripts/prepare_windows_build.py first")
 
-    assert os.path.exists('loristrck/data/libfftw3-3.dll'), (
-        "fftw dll not found. Run scripts/prepare_windows_build.py first"
-        ". Make sure to run that from a terminal in which lib.exe is in the path"
-        " (for example, from a 'Developer Powershell...')")
+        assert os.path.exists('loristrck/data/libfftw3-3.dll'), (
+            "fftw dll not found. Run scripts/prepare_windows_build.py first"
+            ". Make sure to run that from a terminal in which lib.exe is in the path"
+            " (for example, from a 'Developer Powershell...')")
 
     libs = ["libfftw3-3"]
     include_dirs.append('src/loriswin')


### PR DESCRIPTION
Hi @gesellkammer 

I did github actions to builder wheels for windows, Mac and linux, It would be great if it could upload in PyPl using twine...

In Windows OS, I yet need to build the `pysdif3` then, users that do not use VStudio, can not compile pysdif and it is not possible to install loristrck. I was able, in my fork of `pysdif3`, build it for Windows in python 3.8, .9, .10 and .11 but could not do it in Ubuntu or MacOS. I yet do not know why!

But it is a start!
